### PR TITLE
Add ref forwarding to withEventHandlers

### DIFF
--- a/src/withEventHandlers/__tests__/index.js
+++ b/src/withEventHandlers/__tests__/index.js
@@ -26,8 +26,8 @@ describe('withEventHandlers', () => {
 		const WrappedButton = withEventHandlers(handlers, Button);
 
 		const mountedComponent = shallow(
-			<WrappedButton onClick={() => {}} onMouseOver={onMouseOver} rowId={10} />,
-		);
+			<WrappedButton onClick={() => console.log('FAIL')} onMouseOver={onMouseOver} rowId={10} />,
+		).dive();
 
 		// Verify other handlers were not changed
 		assert.strictEqual(onMouseOver, mountedComponent.props().onMouseOver);
@@ -44,8 +44,9 @@ describe('withEventHandlers', () => {
 			</div>
 		);
 		const WrappedComponent = withEventHandlers({}, Button);
-		assert.strictEqual(true, new WrappedComponent() instanceof React.Component);
-		assert.strictEqual(false, new WrappedComponent() instanceof React.PureComponent);
+		const WrappedComponentType = shallow(<WrappedComponent />).type();
+		assert.strictEqual(true, new WrappedComponentType() instanceof React.Component);
+		assert.strictEqual(false, new WrappedComponentType() instanceof React.PureComponent);
 	});
 
 	it('is pure when specified', () => {
@@ -55,7 +56,8 @@ describe('withEventHandlers', () => {
 			</div>
 		);
 		const WrappedComponent = withEventHandlers({}, Button, { isPure: true });
-		assert.strictEqual(true, new WrappedComponent() instanceof React.Component);
-		assert.strictEqual(true, new WrappedComponent() instanceof React.PureComponent);
+		const WrappedComponentType = shallow(<WrappedComponent />).type();
+		assert.strictEqual(true, new WrappedComponentType() instanceof React.Component);
+		assert.strictEqual(true, new WrappedComponentType() instanceof React.PureComponent);
 	});
 });

--- a/src/withEventHandlers/index.js
+++ b/src/withEventHandlers/index.js
@@ -1,4 +1,4 @@
-import React, { PureComponent, Component } from 'react';
+import React, { PureComponent, Component, forwardRef } from 'react';
 
 /** Binds event handlers onto functional components.
  *  Any methods specified as arguments to this function
@@ -9,7 +9,7 @@ import React, { PureComponent, Component } from 'react';
 export function withEventHandlers(eventHandlers, WrappedComponent, options = {}) {
 	const ComponentToExtend = options.isPure ? PureComponent : Component;
 
-	return class WithEventHandlers extends ComponentToExtend {
+	class WithEventHandlers extends ComponentToExtend {
 		static displayName = `WithEventHandlers(${WrappedComponent.displayName ||
 			WrappedComponent.name ||
 			'Unnamed Component'})`;
@@ -25,7 +25,10 @@ export function withEventHandlers(eventHandlers, WrappedComponent, options = {})
 		}
 
 		render() {
-			return <WrappedComponent {...this.props} {...this.eventHandlers} />;
+			const { forwardedRef, ...props } = this.props;
+			return <WrappedComponent {...props} {...this.eventHandlers} ref={forwardedRef} />;
 		}
-	};
+	}
+
+	return forwardRef((props, ref) => <WithEventHandlers {...props} forwardedRef={ref} />);
 }


### PR DESCRIPTION
A ref to the wrapped component can be desired, especially in the case of HTML controls that need focus.

I attempted to add a test of ref forwarding, but I couldn't get enzyme to work correctly with `forwardRef`.